### PR TITLE
Traverse each attribute argument expresssion

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/Traversal.kt
+++ b/src/main/kotlin/com/wgslfuzz/Traversal.kt
@@ -13,7 +13,9 @@ fun <T> traverse(
         is Statement.Continue -> {}
         is Statement.Discard -> {}
         is Statement.Empty -> {}
-        is Attribute -> {}
+        is Attribute -> {
+            node.args.forEach(actionWithState)
+        }
         is Directive -> {}
         is Expression.BoolLiteral -> {}
         is Expression.FloatLiteral -> {}

--- a/src/main/kotlin/com/wgslfuzz/Traversal.kt
+++ b/src/main/kotlin/com/wgslfuzz/Traversal.kt
@@ -13,9 +13,6 @@ fun <T> traverse(
         is Statement.Continue -> {}
         is Statement.Discard -> {}
         is Statement.Empty -> {}
-        is Attribute -> {
-            node.args.forEach(actionWithState)
-        }
         is Directive -> {}
         is Expression.BoolLiteral -> {}
         is Expression.FloatLiteral -> {}
@@ -23,6 +20,9 @@ fun <T> traverse(
         is Expression.IntLiteral -> {}
         is LhsExpression.Identifier -> {}
 
+        is Attribute -> {
+            node.args.forEach(actionWithState)
+        }
         is CaseSelectors.ExpressionsOrDefault -> {
             node.expressions.forEach {
                 it?.let(actionWithState)


### PR DESCRIPTION
The expression arguments of an attribute can be necessary to give the attribute meaning, such as in the case of builtin. Extend traverse to carry out an action on these expressions.

Fixes #12. 