### PR TITLE
Use a function instead of a map to handle replacements during cloning…

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/CloneAst.kt
+++ b/src/main/kotlin/com/wgslfuzz/CloneAst.kt
@@ -1,14 +1,14 @@
 package com.wgslfuzz
 
-fun <T : AstNode?> T.clone(replacements: Map<out AstNode, AstNode> = emptyMap()): T = cloneHelper(this, replacements) as T
+fun <T : AstNode?> T.clone(replacements: (AstNode?) -> AstNode? = { null }): T = cloneHelper(this, replacements) as T
 
-fun <T : AstNode?> List<T>.clone(replacements: Map<out AstNode, AstNode> = emptyMap()): List<T> = map { it.clone(replacements) }
+fun <T : AstNode?> List<T>.clone(replacements: (AstNode?) -> AstNode? = { null }): List<T> = map { it.clone(replacements) }
 
 private fun cloneHelper(
     node: AstNode?,
-    replacements: Map<out AstNode, AstNode>,
+    replacements: (AstNode?) -> AstNode?,
 ): AstNode? =
-    replacements[node] ?: with(node) {
+    replacements(node) ?: with(node) {
         when (this) {
             is Attribute -> Attribute(kind, args.clone(replacements))
             is CaseSelectors.DefaultAlone -> CaseSelectors.DefaultAlone()

--- a/src/test/kotlin/com/wgslfuzz/CloneAstTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/CloneAstTests.kt
@@ -38,7 +38,7 @@ class CloneAstTests {
             mapOf(
                 identifierExpression to Expression.Binary(BinaryOperator.PLUS, Expression.Identifier("x"), Expression.Identifier("y")),
             )
-        val tuCloned = tu.clone(replacement)
+        val tuCloned = tu.clone({ replacement[it] })
         val outputStream = ByteArrayOutputStream()
         AstWriter(
             out = PrintStream(outputStream),
@@ -120,7 +120,7 @@ class CloneAstTests {
                 ),
             )
         val replacement = mapOf(forLoop to replacementForLoop)
-        val tuCloned = tu.clone(replacement)
+        val tuCloned = tu.clone({ replacement[it] })
         val outputStream = ByteArrayOutputStream()
         AstWriter(
             out = PrintStream(outputStream),


### PR DESCRIPTION
…. This allows for more flexible cloning where replacement decisions are made on-the-fly.