### PR TITLE
Traverse each attribute argument expression

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -1849,6 +1849,12 @@ private fun resolveFunctionHeader(
     functionDecl: GlobalDecl.Function,
     resolverState: ResolverState,
 ) {
+    functionDecl.attributes.forEach { attribute ->
+        attribute.args.forEach {
+            resolverState.resolvedEnvironment.recordType(it, resolveExpressionType(it, resolverState))
+        }
+    }
+
     val functionType =
         FunctionType(
             functionDecl.parameters.map {

--- a/src/main/kotlin/com/wgslfuzz/core/Traversal.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Traversal.kt
@@ -12,14 +12,13 @@ fun <T> traverse(
         is Statement.Continue -> {}
         is Statement.Discard -> {}
         is Statement.Empty -> {}
-        is Attribute -> {}
         is Directive -> {}
         is Expression.BoolLiteral -> {}
         is Expression.FloatLiteral -> {}
         is Expression.Identifier -> {}
         is Expression.IntLiteral -> {}
         is LhsExpression.Identifier -> {}
-
+        is Attribute -> node.args.forEach(actionWithState)
         is ContinuingStatement -> {
             node.attributes.forEach(actionWithState)
             actionWithState(node.statements)

--- a/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
@@ -44,9 +44,7 @@ class ResolverTests {
         gatherExpressions(tu, expressions)
 
         // Confirm that a type was found for every expression.
-        expressions.forEach {
-            environment.typeOf(it)
-        }
+        expressions.forEach(environment::typeOf)
 
         val functionDecl = tu.globalDecls[0] as GlobalDecl.Function
         val whileStmt = functionDecl.body.statements[1] as Statement.While
@@ -144,9 +142,7 @@ class ResolverTests {
         gatherExpressions(tu, expressions)
 
         // Confirm that a type was found for every expression.
-        expressions.forEach {
-            environment.typeOf(it)
-        }
+        expressions.forEach(environment::typeOf)
     }
 
     @Test
@@ -375,5 +371,26 @@ class ResolverTests {
         assertNotNull(enclosingScopeContinuingStatementCompound.getEntry("j"))
 
         assertNotSame(enclosingScopeLoopBody.getEntry("x"), enclosingScopeContinuingStatementCompound.getEntry("x"))
+    }
+
+    @Test
+    fun testWorkgroupSizeExpressionsAreTyped() {
+        val input =
+            """
+            @compute
+            @workgroup_size(1, )
+            fn main()
+            {
+            }
+            """.trimIndent()
+        val errorListener = LoggingParseErrorListener()
+        val tu = parseFromString(input, errorListener)
+        val environment = resolve(tu)
+
+        val expressions = mutableSetOf<Expression>()
+        gatherExpressions(tu, expressions)
+        assertEquals(1, expressions.size)
+        val workgroupSize = expressions.toList()[0] as Expression.IntLiteral
+        assertEquals(Type.AbstractInteger, environment.typeOf(workgroupSize))
     }
 }

--- a/src/test/kotlin/com/wgslfuzz/core/TraversalTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/TraversalTests.kt
@@ -2,6 +2,7 @@ package com.wgslfuzz.core
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TraversalTests {
     @Test
@@ -89,5 +90,29 @@ class TraversalTests {
                 tu,
             )
         assertEquals(expectedPostOrder, nodesPostOrder(tu))
+    }
+
+    @Test
+    fun testAttributeTraversal() {
+        val shader =
+            """
+            struct S { a: i32, }
+            @group(0)
+            @binding(0)
+            var<uniform> v: S;
+            """.trimIndent()
+        val tu = parseFromString(shader, LoggingParseErrorListener())
+        val nodes = nodesPreOrder(tu)
+        assertEquals(10, nodes.size)
+        assertTrue(nodes[0] is TranslationUnit)
+        assertTrue(nodes[1] is GlobalDecl.Struct)
+        assertTrue(nodes[2] is StructMember)
+        assertTrue(nodes[3] is TypeDecl.I32)
+        assertTrue(nodes[4] is GlobalDecl.Variable)
+        assertTrue(nodes[5] is Attribute)
+        assertTrue(nodes[6] is Expression.IntLiteral)
+        assertTrue(nodes[7] is Attribute)
+        assertTrue(nodes[8] is Expression.IntLiteral)
+        assertTrue(nodes[9] is TypeDecl.NamedType)
     }
 }


### PR DESCRIPTION
The expression arguments of an attribute can be necessary to give the attribute meaning, such as in the case of builtin. Extend traverse to carry out an action on these expressions, with associated test.

Co-authored by James Lee-Jones.

Fixes #12.