### PR TITLE
Implement reference types faithfully

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -391,9 +391,30 @@ private fun resolveAstNode(
                         resolveTypeDecl(node.typeDecl, resolverState)
                     } ?: resolverState.resolvedEnvironment.typeOf(node.initializer!!),
                 )
+
+            // TODO(JLJ): Correctly handle the 'handle' address space.
+            if (node.addressSpace == AddressSpace.FUNCTION) {
+                throw IllegalArgumentException(
+                    "Variables in the function address space must only be declared in function scope.",
+                )
+            } else if (node.accessMode != null && node.addressSpace == null) {
+                throw IllegalArgumentException(
+                    "If an access mode is specified for a variable an address space must also be specified.",
+                )
+            } else if (node.addressSpace != AddressSpace.STORAGE && node.accessMode != null) {
+                throw IllegalArgumentException(
+                    "The access mode must not be specified unless a variable is in the storage address space.",
+                )
+            }
+
+            // TODO(JLJ): Reduce duplication with non-global case
+            val addressSpace = node.addressSpace ?: AddressSpace.FUNCTION
+            val accessMode = node.accessMode ?: defaultAccessModeOf(addressSpace)
+            val refType = type as? Type.Reference ?: Type.Reference(type, addressSpace, accessMode)
+
             resolverState.currentScope.addEntry(
                 node.name,
-                ScopeEntry.GlobalVariable(node, type),
+                ScopeEntry.GlobalVariable(node, refType),
             )
         }
         is GlobalDecl.Constant -> {
@@ -476,6 +497,33 @@ private fun resolveAstNode(
             if (type.isAbstract()) {
                 type = defaultConcretizationOf(type)
             }
+
+            if (node.accessMode != null && node.addressSpace == null) {
+                throw IllegalArgumentException(
+                    "If an access mode is specified for a variable an address space must also be specified.",
+                )
+            } else if (node.addressSpace in
+                setOf(
+                    AddressSpace.PRIVATE,
+                    AddressSpace.STORAGE,
+                    AddressSpace.UNIFORM,
+                    AddressSpace.WORKGROUP,
+                    AddressSpace.HANDLE,
+                )
+            ) {
+                throw IllegalArgumentException(
+                    "The address spaces private, storage, uniform, workgroup and handle can only be used for module scope variables",
+                )
+            } else if (node.accessMode != null) {
+                throw IllegalArgumentException(
+                    "The access mode must not be specified unless a variable is in the storage address space.",
+                )
+            }
+
+            val addressSpace = node.addressSpace ?: AddressSpace.FUNCTION
+            val accessMode = defaultAccessModeOf(addressSpace)
+            type = type as? Type.Reference ?: Type.Reference(type, addressSpace, accessMode)
+
             resolverState.currentScope.addEntry(
                 node.name,
                 ScopeEntry.LocalVariable(node, type),
@@ -510,6 +558,22 @@ private fun nodeIntroducesNewScope(
             parentNode !is ContinuingStatement
     )
 
+private fun <T : Type> T.concreteType(): Type =
+    when (this) {
+        is Type.Reference -> this.storeType
+        else -> this
+    }
+
+private fun defaultAccessModeOf(addressSpace: AddressSpace): AccessMode =
+    when (addressSpace) {
+        AddressSpace.FUNCTION -> AccessMode.READ_WRITE
+        AddressSpace.PRIVATE -> AccessMode.READ_WRITE
+        AddressSpace.WORKGROUP -> AccessMode.READ_WRITE
+        AddressSpace.UNIFORM -> AccessMode.READ
+        AddressSpace.STORAGE -> AccessMode.READ
+        AddressSpace.HANDLE -> AccessMode.READ
+    }
+
 private fun resolveExpressionType(
     expression: Expression,
     resolverState: ResolverState,
@@ -526,12 +590,25 @@ private fun resolveExpressionType(
                 is Type.Vector -> targetType.elementType
                 is Type.Array -> targetType.elementType
                 is Type.Pointer -> {
-                    when (val pointeeType = targetType.pointeeType) {
-                        is Type.Vector -> pointeeType.elementType
-                        is Type.Array -> pointeeType.elementType
-                        is Type.Matrix -> Type.Vector(pointeeType.numRows, pointeeType.elementType)
-                        else -> TODO("Index lookup on pointer with pointee type ${targetType.pointeeType}")
-                    }
+                    val newPointeeType =
+                        when (val pointeeType = targetType.pointeeType) {
+                            is Type.Vector -> pointeeType.elementType
+                            is Type.Array -> pointeeType.elementType
+                            is Type.Matrix -> Type.Vector(pointeeType.numRows, pointeeType.elementType)
+                            else -> TODO("Index lookup on pointer with pointee type ${targetType.pointeeType}")
+                        }
+                    Type.Pointer(newPointeeType, targetType.addressSpace, targetType.accessMode)
+                }
+                // TODO(JLJ): Reduce duplication with the above.
+                is Type.Reference -> {
+                    val newStoreType =
+                        when (val storeType = targetType.storeType) {
+                            is Type.Vector -> storeType.elementType
+                            is Type.Array -> storeType.elementType
+                            is Type.Matrix -> Type.Vector(storeType.numRows, storeType.elementType)
+                            else -> TODO("Index lookup on pointer with pointee type ${targetType.storeType}")
+                        }
+                    Type.Reference(newStoreType, targetType.addressSpace, targetType.accessMode)
                 }
                 else -> throw IllegalArgumentException("Index lookup attempted on unsuitable type $targetType")
             }
@@ -544,7 +621,7 @@ private fun resolveExpressionType(
                         }?. second
                         ?: throw IllegalArgumentException("Struct with type $receiverType does not have a member ${expression.memberName}")
                 is Type.Vector ->
-                    // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
+                    // In the following, we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
                     if (expression.memberName in setOf("x", "y", "z", "w", "r", "g", "b", "a")) {
                         receiverType.elementType
                     } else if (isSwizzle(expression.memberName)) {
@@ -552,27 +629,61 @@ private fun resolveExpressionType(
                     } else {
                         TODO()
                     }
-                is Type.Pointer ->
-                    when (val pointeeType = receiverType.pointeeType) {
-                        is Type.Vector ->
-                            // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
-                            if (expression.memberName in setOf("x", "y", "z", "w")) {
-                                pointeeType.elementType
-                            } else if (isSwizzle(expression.memberName)) {
-                                Type.Vector(expression.memberName.length, pointeeType.elementType)
-                            } else {
-                                TODO()
-                            }
-                        is Type.Struct ->
-                            pointeeType.members
-                                .firstOrNull {
-                                    it.first == expression.memberName
-                                }?. second
-                                ?: throw IllegalArgumentException(
-                                    "Struct with type $receiverType does not have a member ${expression.memberName}",
-                                )
-                        else -> TODO("${receiverType.pointeeType}")
-                    }
+                is Type.Pointer -> {
+                    val newPointeeType =
+                        when (val pointeeType = receiverType.pointeeType) {
+                            is Type.Vector ->
+                                // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
+                                // TODO(JLJ): Is there any reason there are fewer member names here?
+                                if (expression.memberName in setOf("x", "y", "z", "w")) {
+                                    pointeeType.elementType
+                                } else if (isSwizzle(expression.memberName)) {
+                                    Type.Vector(expression.memberName.length, pointeeType.elementType)
+                                } else {
+                                    TODO()
+                                }
+
+                            is Type.Struct ->
+                                pointeeType.members
+                                    .firstOrNull {
+                                        it.first == expression.memberName
+                                    }?.second
+                                    ?: throw IllegalArgumentException(
+                                        "Struct with type $receiverType does not have a member ${expression.memberName}",
+                                    )
+
+                            else -> TODO("${receiverType.pointeeType}")
+                        }
+                    Type.Pointer(newPointeeType, receiverType.addressSpace, receiverType.accessMode)
+                }
+                // TODO(JLJ): Reduce duplication with the above1
+                is Type.Reference -> {
+                    val newStoreType =
+                        when (val storeType = receiverType.storeType) {
+                            is Type.Vector ->
+                                // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
+                                // TODO(JLJ): Is there any reason there are fewer member names here?
+                                if (expression.memberName in setOf("x", "y", "z", "w", "r", "g", "b", "a")) {
+                                    storeType.elementType
+                                } else if (isSwizzle(expression.memberName)) {
+                                    Type.Vector(expression.memberName.length, storeType.elementType)
+                                } else {
+                                    TODO()
+                                }
+
+                            is Type.Struct ->
+                                storeType.members
+                                    .firstOrNull {
+                                        it.first == expression.memberName
+                                    }?.second
+                                    ?: throw IllegalArgumentException(
+                                        "Struct with type $receiverType does not have a member ${expression.memberName}",
+                                    )
+
+                            else -> TODO("${receiverType.storeType}")
+                        }
+                    Type.Reference(newStoreType, receiverType.addressSpace, receiverType.accessMode)
+                }
                 else -> throw UnsupportedOperationException("Member lookup not implemented for receiver of type $receiverType")
             }
         is Expression.FloatLiteral ->
@@ -669,19 +780,11 @@ private fun resolveLhsExpressionType(
                 }
                 is ScopeEntry.LocalVariable -> {
                     assert(scopeEntry.type !is Type.Pointer)
-                    Type.Reference(
-                        scopeEntry.type,
-                        scopeEntry.astNode.addressSpace ?: AddressSpace.FUNCTION,
-                        scopeEntry.astNode.accessMode ?: AccessMode.READ_WRITE,
-                    )
+                    scopeEntry.type
                 }
                 is ScopeEntry.GlobalVariable -> {
                     assert(scopeEntry.type !is Type.Pointer)
-                    Type.Reference(
-                        scopeEntry.type,
-                        scopeEntry.astNode.addressSpace ?: AddressSpace.FUNCTION,
-                        scopeEntry.astNode.accessMode ?: AccessMode.READ_WRITE,
-                    )
+                    scopeEntry.type
                 }
                 else -> throw RuntimeException("Unsuitable scope entry for identifier occurring in LHS expression")
             }
@@ -706,6 +809,7 @@ private fun resolveLhsExpressionType(
                     "Index lookup in LHS expression applied to expression ${lhsExpression.target} with non-reference / pointer type",
                 )
             }
+
             when (storeType) {
                 is Type.Vector -> Type.Reference(storeType.elementType, addressSpace, accessMode)
                 is Type.Array -> Type.Reference(storeType.elementType, addressSpace, accessMode)
@@ -750,7 +854,7 @@ private fun resolveLhsExpressionType(
                         accessMode,
                     )
                 is Type.Vector -> Type.Reference(storeType.elementType, addressSpace, accessMode)
-                else -> throw RuntimeException("Index lookup in LHS expression applied to non-indexable reference")
+                else -> throw RuntimeException("Member lookup in LHS expression applied to non-indexable reference")
             }
         }
         is LhsExpression.Paren -> resolverState.resolvedEnvironment.typeOf(lhsExpression.target)
@@ -765,15 +869,20 @@ private fun resolveUnary(
         if (pointerType !is Type.Pointer) {
             throw RuntimeException("Dereference applied to expression $expression with non-pointer type")
         }
-        pointerType.pointeeType
+        Type.Reference(pointerType.pointeeType, pointerType.addressSpace, pointerType.accessMode)
     }
 
     UnaryOperator.ADDRESS_OF -> {
-        resolveTypeOfAddressOfExpression(expression, resolverState)
+        val referenceType = resolverState.resolvedEnvironment.typeOf(expression.target)
+        if (referenceType !is Type.Reference) {
+            throw RuntimeException("Address-of applied to expression $expression with non-reference type")
+        }
+        Type.Pointer(referenceType.storeType, referenceType.addressSpace, referenceType.accessMode)
     }
 
     UnaryOperator.LOGICAL_NOT -> {
-        assert(resolverState.resolvedEnvironment.typeOf(expression.target) == Type.Bool)
+        val targetType = resolverState.resolvedEnvironment.typeOf(expression.target)
+        assert(targetType == Type.Bool || (targetType is Type.Reference && targetType.storeType is Type.Bool))
         Type.Bool
     }
 
@@ -784,19 +893,27 @@ private fun resolveBinary(
     resolverState: ResolverState,
     expression: Expression.Binary,
 ): Type {
-    val lhsType = resolverState.resolvedEnvironment.typeOf(expression.lhs)
-    val rhsType = resolverState.resolvedEnvironment.typeOf(expression.rhs)
+    val lhsType = resolverState.resolvedEnvironment.typeOf(expression.lhs).concreteType()
+    val rhsType = resolverState.resolvedEnvironment.typeOf(expression.rhs).concreteType()
     return when (val operator = expression.operator) {
         BinaryOperator.LESS_THAN,
         BinaryOperator.LESS_THAN_EQUAL,
         BinaryOperator.GREATER_THAN,
         BinaryOperator.GREATER_THAN_EQUAL,
-        ->
-            when (lhsType) {
-                is Type.Scalar -> Type.Bool
-                is Type.Vector -> Type.Vector(lhsType.width, Type.Bool)
-                else -> TODO("$lhsType")
+        -> {
+            // TODO(JL): Reduce duplication.
+            if (!rhsType.isAbstractionOf(lhsType) &&
+                !lhsType.isAbstractionOf(rhsType)
+            ) {
+                TODO("$operator not supported for $lhsType and $rhsType")
             }
+            if (lhsType is Type.Scalar || (lhsType is Type.Reference && lhsType.storeType is Type.Scalar)) {
+                return Type.Bool
+            } else if (lhsType is Type.Vector) {
+                return Type.Vector(lhsType.width, Type.Bool)
+            }
+            TODO("$lhsType")
+        }
 
         BinaryOperator.PLUS, BinaryOperator.MINUS, BinaryOperator.DIVIDE, BinaryOperator.MODULO ->
             if (rhsType.isAbstractionOf(lhsType)) {
@@ -919,7 +1036,7 @@ private fun resolveTypeOfVectorValueConstructor(
         } else {
             var candidateElementType: Type.Scalar? = null
             for (arg in expression.args) {
-                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg)
+                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).concreteType()
                 when (elementTypeForArg) {
                     is Type.Scalar -> {
                         // Nothing to do
@@ -956,7 +1073,7 @@ private fun resolveTypeOfMatrixValueConstructor(
         } ?: run {
             var candidateElementType: Type.Scalar? = null
             for (arg in expression.args) {
-                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg)
+                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).concreteType()
                 when (elementTypeForArg) {
                     is Type.Float -> {
                         // Nothing to do
@@ -1114,8 +1231,8 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("cross builtin takes two arguments")
                     }
-                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
-                    val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1])
+                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                    val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).concreteType()
                     if (arg1Type !is Type.Vector || arg2Type !is Type.Vector) {
                         throw RuntimeException("cross builtin requires vector arguments")
                     }
@@ -1134,7 +1251,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("determinant builtin function requires one argument")
                     }
-                    val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
+                    val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
                     if (argType !is Type.Matrix) {
                         throw RuntimeException("determinant builtin function requires a matrix argument")
                     }
@@ -1147,7 +1264,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("$calleeName requires two arguments")
                     }
-                    val commonType = findCommonType(functionCallExpression.args, resolverState)
+                    val commonType = findCommonType(functionCallExpression.args, resolverState).concreteType()
                     if (commonType is Type.Vector) {
                         commonType.elementType
                     } else {
@@ -1158,7 +1275,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("dot requires two arguments")
                     }
-                    val commonType = findCommonType(functionCallExpression.args, resolverState)
+                    val commonType = findCommonType(functionCallExpression.args, resolverState).concreteType()
                     if (commonType is Type.Vector) {
                         commonType.elementType
                     } else {
@@ -1183,7 +1300,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("frexp requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
                         Type.F16 -> FrexpResultF16
                         Type.F32 -> FrexpResultF32
                         Type.AbstractFloat, Type.AbstractInteger -> FrexpResultAbstract
@@ -1242,10 +1359,10 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("length requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
                         is Type.Float -> argType
                         is Type.Vector -> argType.elementType
-                        else -> throw RuntimeException("Unsupported argument for length builtin function")
+                        else -> throw RuntimeException("Unsupported argument type for length builtin function")
                     }
                 }
                 "mat2x2f" -> Type.Matrix(2, 2, Type.F32)
@@ -1274,7 +1391,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("modf requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
                         Type.F16 -> ModfResultF16
                         Type.F32 -> ModfResultF32
                         Type.AbstractFloat -> ModfResultAbstract
@@ -1324,7 +1441,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size !in 1..2) {
                         throw RuntimeException("textureDimensions requires two arguments")
                     }
-                    val textureType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
+                    val textureType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
                     if (textureType !is Type.Texture) {
                         throw RuntimeException("Type of first argument to textureDimensions must be a texture")
                     }
@@ -1369,14 +1486,14 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size < 2) {
                         throw RuntimeException("$calleeName requires at least 2 arguments")
                     }
-                    when (resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])) {
+                    when (resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
                         Type.Texture.Depth2D, Type.Texture.DepthCube, Type.Texture.Depth2DArray, Type.Texture.DepthCubeArray ->
                             Type.Vector(
                                 4,
                                 Type.F32,
                             )
                         else -> {
-                            when (val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1])) {
+                            when (val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).concreteType()) {
                                 is Type.Texture.Sampled -> Type.Vector(4, arg2Type.sampledType)
                                 else -> throw RuntimeException("$calleeName requires a suitable texture as its first or second argument")
                             }
@@ -1388,7 +1505,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.isEmpty()) {
                         throw RuntimeException("textureLoad requires a first argument of texture type")
                     }
-                    val textureArg = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
+                    val textureArg = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
                     if (textureArg !is Type.Texture) {
                         throw RuntimeException("textureLoad requires a first argument of texture type")
                     }
@@ -1414,7 +1531,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     } else {
                         when (
                             val textureType =
-                                resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
+                                resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
                         ) {
                             is Type.Texture.Sampled ->
                                 if (textureType.sampledType is Type.F32) {
@@ -1434,7 +1551,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("$calleeName requires one argument")
                     }
-                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0])
+                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
                     if (arg1Type is Type.Matrix) {
                         Type.Matrix(
                             numCols = arg1Type.numRows,
@@ -1493,7 +1610,9 @@ private fun resolveTypeOfAddressOfExpression(
         target =
             when (target) {
                 is Expression.Paren -> target.target
-                is Expression.MemberLookup -> target.receiver
+                is Expression.MemberLookup -> {
+                    target.receiver
+                }
                 is Expression.Unary -> {
                     when (target.operator) {
                         UnaryOperator.ADDRESS_OF, UnaryOperator.DEREFERENCE -> target.target
@@ -1507,29 +1626,26 @@ private fun resolveTypeOfAddressOfExpression(
     }
     val targetType = resolverState.resolvedEnvironment.typeOf(target)
     val pointeeType = resolverState.resolvedEnvironment.typeOf(expression.target)
-    return if (targetType is Type.Pointer) {
-        Type.Pointer(
-            pointeeType = pointeeType,
-            addressSpace = targetType.addressSpace,
-            accessMode = targetType.accessMode,
-        )
-    } else {
-        when (val scopeEntry = resolverState.currentScope.getEntry(target.name)) {
-            is ScopeEntry.GlobalVariable ->
-                Type.Pointer(
-                    pointeeType = pointeeType,
-                    // The spec seems to indicate that "handle" is the default for module-level variable declarations
-                    // for which no address space is specified.
-                    addressSpace = scopeEntry.astNode.addressSpace ?: AddressSpace.HANDLE,
-                    accessMode = scopeEntry.astNode.accessMode ?: AccessMode.READ_WRITE,
-                )
-            is ScopeEntry.LocalVariable ->
-                Type.Pointer(
-                    pointeeType = pointeeType,
-                    addressSpace = scopeEntry.astNode.addressSpace ?: AddressSpace.FUNCTION,
-                    accessMode = scopeEntry.astNode.accessMode ?: AccessMode.READ_WRITE,
-                )
-            else -> TODO("Unsupported target for address-of - scope entry is $scopeEntry")
+
+    return when (targetType) {
+        is Type.Pointer -> {
+            Type.Pointer(
+                pointeeType = pointeeType,
+                addressSpace = targetType.addressSpace,
+                accessMode = targetType.accessMode,
+            )
+        }
+
+        is Type.Reference -> {
+            Type.Pointer(
+                pointeeType = pointeeType,
+                addressSpace = targetType.addressSpace,
+                accessMode = targetType.accessMode,
+            )
+        }
+
+        else -> {
+            TODO("Unsupported target for address-of $targetType")
         }
     }
 }
@@ -1643,7 +1759,7 @@ private fun TexelFormat.toVectorElementType(): Type.Scalar =
     }
 
 private fun Type.isAbstractionOf(maybeConcretizedVersion: Type): Boolean =
-    if (this == maybeConcretizedVersion) {
+    if (this == maybeConcretizedVersion || (this is Type.Reference && maybeConcretizedVersion.isAbstractionOf(this.storeType))) {
         true
     } else {
         when (this) {

--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -392,7 +392,7 @@ private fun resolveAstNode(
                     } ?: resolverState.resolvedEnvironment.typeOf(node.initializer!!),
                 )
 
-            // TODO(JLJ): Correctly handle the 'handle' address space.
+            // TODO: Error if the handle address space is used incorrectly
             if (node.addressSpace == AddressSpace.FUNCTION) {
                 throw IllegalArgumentException(
                     "Variables in the function address space must only be declared in function scope.",
@@ -407,7 +407,6 @@ private fun resolveAstNode(
                 )
             }
 
-            // TODO(JLJ): Reduce duplication with non-global case
             val addressSpace = node.addressSpace ?: AddressSpace.FUNCTION
             val accessMode = node.accessMode ?: defaultAccessModeOf(addressSpace)
             val refType = type as? Type.Reference ?: Type.Reference(type, addressSpace, accessMode)
@@ -558,7 +557,7 @@ private fun nodeIntroducesNewScope(
             parentNode !is ContinuingStatement
     )
 
-private fun <T : Type> T.concreteType(): Type =
+private fun <T : Type> T.asStoreType(): Type =
     when (this) {
         is Type.Reference -> this.storeType
         else -> this
@@ -580,112 +579,65 @@ private fun resolveExpressionType(
 ): Type =
     when (expression) {
         is Expression.FunctionCall -> resolveTypeOfFunctionCallExpression(expression, resolverState)
-        is Expression.IndexLookup ->
+        is Expression.IndexLookup -> {
+            fun resolveDirectIndexType(type: Type) =
+                when (type) {
+                    is Type.Matrix -> Type.Vector(width = type.numRows, elementType = type.elementType)
+                    is Type.Vector -> type.elementType
+                    is Type.Array -> type.elementType
+                    else -> throw IllegalArgumentException("Index lookup attempted on unsuitable type $type")
+                }
+
             when (val targetType = resolverState.resolvedEnvironment.typeOf(expression.target)) {
-                is Type.Matrix ->
-                    Type.Vector(
-                        width = targetType.numRows,
-                        elementType = targetType.elementType,
-                    )
-                is Type.Vector -> targetType.elementType
-                is Type.Array -> targetType.elementType
                 is Type.Pointer -> {
-                    val newPointeeType =
-                        when (val pointeeType = targetType.pointeeType) {
-                            is Type.Vector -> pointeeType.elementType
-                            is Type.Array -> pointeeType.elementType
-                            is Type.Matrix -> Type.Vector(pointeeType.numRows, pointeeType.elementType)
-                            else -> TODO("Index lookup on pointer with pointee type ${targetType.pointeeType}")
-                        }
+                    val newPointeeType = resolveDirectIndexType(targetType.pointeeType)
                     Type.Pointer(newPointeeType, targetType.addressSpace, targetType.accessMode)
                 }
-                // TODO(JLJ): Reduce duplication with the above.
                 is Type.Reference -> {
-                    val newStoreType =
-                        when (val storeType = targetType.storeType) {
-                            is Type.Vector -> storeType.elementType
-                            is Type.Array -> storeType.elementType
-                            is Type.Matrix -> Type.Vector(storeType.numRows, storeType.elementType)
-                            else -> TODO("Index lookup on pointer with pointee type ${targetType.storeType}")
-                        }
+                    val newStoreType = resolveDirectIndexType(targetType.storeType)
                     Type.Reference(newStoreType, targetType.addressSpace, targetType.accessMode)
                 }
-                else -> throw IllegalArgumentException("Index lookup attempted on unsuitable type $targetType")
+                else -> resolveDirectIndexType(targetType)
             }
-        is Expression.MemberLookup ->
-            when (val receiverType = resolverState.resolvedEnvironment.typeOf(expression.receiver)) {
-                is Type.Struct ->
-                    receiverType.members
-                        .firstOrNull {
-                            it.first == expression.memberName
-                        }?. second
-                        ?: throw IllegalArgumentException("Struct with type $receiverType does not have a member ${expression.memberName}")
-                is Type.Vector ->
-                    // In the following, we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
-                    if (expression.memberName in setOf("x", "y", "z", "w", "r", "g", "b", "a")) {
-                        receiverType.elementType
-                    } else if (isSwizzle(expression.memberName)) {
-                        Type.Vector(expression.memberName.length, receiverType.elementType)
-                    } else {
-                        TODO()
-                    }
-                is Type.Pointer -> {
-                    val newPointeeType =
-                        when (val pointeeType = receiverType.pointeeType) {
-                            is Type.Vector ->
-                                // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
-                                // TODO(JLJ): Is there any reason there are fewer member names here?
-                                if (expression.memberName in setOf("x", "y", "z", "w")) {
-                                    pointeeType.elementType
-                                } else if (isSwizzle(expression.memberName)) {
-                                    Type.Vector(expression.memberName.length, pointeeType.elementType)
-                                } else {
-                                    TODO()
-                                }
+        }
+        is Expression.MemberLookup -> {
+            fun resolveDirectMemberLookupType(receiverType: Type) =
+                when (receiverType) {
+                    is Type.Struct ->
+                        receiverType.members
+                            .firstOrNull {
+                                it.first == expression.memberName
+                            }?.second
+                            ?: throw IllegalArgumentException(
+                                "Struct with type $receiverType does not have a member ${expression.memberName}",
+                            )
 
-                            is Type.Struct ->
-                                pointeeType.members
-                                    .firstOrNull {
-                                        it.first == expression.memberName
-                                    }?.second
-                                    ?: throw IllegalArgumentException(
-                                        "Struct with type $receiverType does not have a member ${expression.memberName}",
-                                    )
-
-                            else -> TODO("${receiverType.pointeeType}")
+                    is Type.Vector ->
+                        // In the following, we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
+                        if (expression.memberName in setOf("x", "y", "z", "w", "r", "g", "b", "a")) {
+                            receiverType.elementType
+                        } else if (isSwizzle(expression.memberName)) {
+                            Type.Vector(expression.memberName.length, receiverType.elementType)
+                        } else {
+                            TODO()
                         }
+
+                    else -> throw UnsupportedOperationException("Member lookup not implemented for receiver of type $receiverType")
+                }
+
+            when (val receiverType = resolverState.resolvedEnvironment.typeOf(expression.receiver)) {
+                is Type.Pointer -> {
+                    val newPointeeType = resolveDirectMemberLookupType(receiverType.pointeeType)
                     Type.Pointer(newPointeeType, receiverType.addressSpace, receiverType.accessMode)
                 }
-                // TODO(JLJ): Reduce duplication with the above1
                 is Type.Reference -> {
-                    val newStoreType =
-                        when (val storeType = receiverType.storeType) {
-                            is Type.Vector ->
-                                // In the following we could check whether the vector indices exist, e.g. using z on a vec2 is not be allowed.
-                                // TODO(JLJ): Is there any reason there are fewer member names here?
-                                if (expression.memberName in setOf("x", "y", "z", "w", "r", "g", "b", "a")) {
-                                    storeType.elementType
-                                } else if (isSwizzle(expression.memberName)) {
-                                    Type.Vector(expression.memberName.length, storeType.elementType)
-                                } else {
-                                    TODO()
-                                }
-
-                            is Type.Struct ->
-                                storeType.members
-                                    .firstOrNull {
-                                        it.first == expression.memberName
-                                    }?.second
-                                    ?: throw IllegalArgumentException(
-                                        "Struct with type $receiverType does not have a member ${expression.memberName}",
-                                    )
-
-                            else -> TODO("${receiverType.storeType}")
-                        }
+                    val newStoreType = resolveDirectMemberLookupType(receiverType.storeType)
                     Type.Reference(newStoreType, receiverType.addressSpace, receiverType.accessMode)
                 }
-                else -> throw UnsupportedOperationException("Member lookup not implemented for receiver of type $receiverType")
+
+                else -> resolveDirectMemberLookupType(receiverType)
             }
+        }
         is Expression.FloatLiteral ->
             if (expression.text.endsWith("f")) {
                 Type.F32
@@ -737,8 +689,8 @@ private fun resolveExpressionType(
         is AugmentedExpression.TrueByConstruction -> resolverState.resolvedEnvironment.typeOf(expression.trueExpression)
         is AugmentedExpression.IdentityOperation -> resolverState.resolvedEnvironment.typeOf(expression.originalExpression)
         is AugmentedExpression.KnownValue -> {
-            val knownValueType = resolverState.resolvedEnvironment.typeOf(expression.knownValue).concreteType()
-            val expressionType = resolverState.resolvedEnvironment.typeOf(expression.expression).concreteType()
+            val knownValueType = resolverState.resolvedEnvironment.typeOf(expression.knownValue).asStoreType()
+            val expressionType = resolverState.resolvedEnvironment.typeOf(expression.expression).asStoreType()
             if (knownValueType != expressionType) {
                 throw RuntimeException("Types for known value expression and its corresponding obfuscated expression do not match.")
             }
@@ -893,15 +845,14 @@ private fun resolveBinary(
     resolverState: ResolverState,
     expression: Expression.Binary,
 ): Type {
-    val lhsType = resolverState.resolvedEnvironment.typeOf(expression.lhs).concreteType()
-    val rhsType = resolverState.resolvedEnvironment.typeOf(expression.rhs).concreteType()
+    val lhsType = resolverState.resolvedEnvironment.typeOf(expression.lhs).asStoreType()
+    val rhsType = resolverState.resolvedEnvironment.typeOf(expression.rhs).asStoreType()
     return when (val operator = expression.operator) {
         BinaryOperator.LESS_THAN,
         BinaryOperator.LESS_THAN_EQUAL,
         BinaryOperator.GREATER_THAN,
         BinaryOperator.GREATER_THAN_EQUAL,
         -> {
-            // TODO(JL): Reduce duplication.
             if (!rhsType.isAbstractionOf(lhsType) &&
                 !lhsType.isAbstractionOf(rhsType)
             ) {
@@ -1036,7 +987,7 @@ private fun resolveTypeOfVectorValueConstructor(
         } else {
             var candidateElementType: Type.Scalar? = null
             for (arg in expression.args) {
-                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).concreteType()
+                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).asStoreType()
                 when (elementTypeForArg) {
                     is Type.Scalar -> {
                         // Nothing to do
@@ -1073,7 +1024,7 @@ private fun resolveTypeOfMatrixValueConstructor(
         } ?: run {
             var candidateElementType: Type.Scalar? = null
             for (arg in expression.args) {
-                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).concreteType()
+                var elementTypeForArg = resolverState.resolvedEnvironment.typeOf(arg).asStoreType()
                 when (elementTypeForArg) {
                     is Type.Float -> {
                         // Nothing to do
@@ -1231,8 +1182,8 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("cross builtin takes two arguments")
                     }
-                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
-                    val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).concreteType()
+                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
+                    val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).asStoreType()
                     if (arg1Type !is Type.Vector || arg2Type !is Type.Vector) {
                         throw RuntimeException("cross builtin requires vector arguments")
                     }
@@ -1251,7 +1202,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("determinant builtin function requires one argument")
                     }
-                    val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                    val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
                     if (argType !is Type.Matrix) {
                         throw RuntimeException("determinant builtin function requires a matrix argument")
                     }
@@ -1264,7 +1215,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("$calleeName requires two arguments")
                     }
-                    val commonType = findCommonType(functionCallExpression.args, resolverState).concreteType()
+                    val commonType = findCommonType(functionCallExpression.args, resolverState).asStoreType()
                     if (commonType is Type.Vector) {
                         commonType.elementType
                     } else {
@@ -1275,7 +1226,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 2) {
                         throw RuntimeException("dot requires two arguments")
                     }
-                    val commonType = findCommonType(functionCallExpression.args, resolverState).concreteType()
+                    val commonType = findCommonType(functionCallExpression.args, resolverState).asStoreType()
                     if (commonType is Type.Vector) {
                         commonType.elementType
                     } else {
@@ -1300,7 +1251,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("frexp requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()) {
                         Type.F16 -> FrexpResultF16
                         Type.F32 -> FrexpResultF32
                         Type.AbstractFloat, Type.AbstractInteger -> FrexpResultAbstract
@@ -1359,7 +1310,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("length requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()) {
                         is Type.Float -> argType
                         is Type.Vector -> argType.elementType
                         else -> throw RuntimeException("Unsupported argument type for length builtin function")
@@ -1391,7 +1342,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("modf requires one argument")
                     }
-                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
+                    when (val argType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()) {
                         Type.F16 -> ModfResultF16
                         Type.F32 -> ModfResultF32
                         Type.AbstractFloat -> ModfResultAbstract
@@ -1441,7 +1392,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size !in 1..2) {
                         throw RuntimeException("textureDimensions requires two arguments")
                     }
-                    val textureType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                    val textureType = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
                     if (textureType !is Type.Texture) {
                         throw RuntimeException("Type of first argument to textureDimensions must be a texture")
                     }
@@ -1486,14 +1437,14 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size < 2) {
                         throw RuntimeException("$calleeName requires at least 2 arguments")
                     }
-                    when (resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()) {
+                    when (resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()) {
                         Type.Texture.Depth2D, Type.Texture.DepthCube, Type.Texture.Depth2DArray, Type.Texture.DepthCubeArray ->
                             Type.Vector(
                                 4,
                                 Type.F32,
                             )
                         else -> {
-                            when (val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).concreteType()) {
+                            when (val arg2Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[1]).asStoreType()) {
                                 is Type.Texture.Sampled -> Type.Vector(4, arg2Type.sampledType)
                                 else -> throw RuntimeException("$calleeName requires a suitable texture as its first or second argument")
                             }
@@ -1505,7 +1456,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.isEmpty()) {
                         throw RuntimeException("textureLoad requires a first argument of texture type")
                     }
-                    val textureArg = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                    val textureArg = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
                     if (textureArg !is Type.Texture) {
                         throw RuntimeException("textureLoad requires a first argument of texture type")
                     }
@@ -1531,7 +1482,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     } else {
                         when (
                             val textureType =
-                                resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                                resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
                         ) {
                             is Type.Texture.Sampled ->
                                 if (textureType.sampledType is Type.F32) {
@@ -1551,7 +1502,7 @@ private fun resolveTypeOfFunctionCallExpression(
                     if (functionCallExpression.args.size != 1) {
                         throw RuntimeException("$calleeName requires one argument")
                     }
-                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).concreteType()
+                    val arg1Type = resolverState.resolvedEnvironment.typeOf(functionCallExpression.args[0]).asStoreType()
                     if (arg1Type is Type.Matrix) {
                         Type.Matrix(
                             numCols = arg1Type.numRows,

--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -737,8 +737,8 @@ private fun resolveExpressionType(
         is AugmentedExpression.TrueByConstruction -> resolverState.resolvedEnvironment.typeOf(expression.trueExpression)
         is AugmentedExpression.IdentityOperation -> resolverState.resolvedEnvironment.typeOf(expression.originalExpression)
         is AugmentedExpression.KnownValue -> {
-            val knownValueType = resolverState.resolvedEnvironment.typeOf(expression.knownValue)
-            val expressionType = resolverState.resolvedEnvironment.typeOf(expression.expression)
+            val knownValueType = resolverState.resolvedEnvironment.typeOf(expression.knownValue).concreteType()
+            val expressionType = resolverState.resolvedEnvironment.typeOf(expression.expression).concreteType()
             if (knownValueType != expressionType) {
                 throw RuntimeException("Types for known value expression and its corresponding obfuscated expression do not match.")
             }

--- a/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
@@ -93,7 +93,12 @@ class ParseTintTests {
                 text.contains("enable subgroups") ||
                 // binding_array is not currently mentioned in the WGSL specification, but online
                 // research suggests that it is a naga extension.
-                text.contains("binding_array")
+                text.contains("binding_array") ||
+                // TODO(JLJ): Unknown texel formats, trivial to support.
+                text.contains("textureDimensions") ||
+                text.contains("textureNumLayers") ||
+                text.contains("textureLoad") ||
+                text.contains("textureStore")
             ) {
                 return@forEach
             }

--- a/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
@@ -211,7 +211,7 @@ class ResolverTests {
             assertEquals(Type.F32, outerEntryX.type)
             val outerEntryV = scopeAtEndOfFunctionBody.getEntry("v") as ScopeEntry.GlobalVariable
             assertSame(vGlobal, outerEntryV.astNode)
-            assertEquals(Type.I32, outerEntryV.type)
+            assertEquals(Type.Reference(Type.I32, AddressSpace.FUNCTION, AccessMode.READ_WRITE), outerEntryV.type)
             val outerEntryY = scopeAtEndOfFunctionBody.getEntry("y") as ScopeEntry.Parameter
             assertSame(yParam, outerEntryY.astNode)
             assertEquals(Type.I32, outerEntryY.type)
@@ -227,7 +227,7 @@ class ResolverTests {
             assertEquals(Type.F32, inner1EntryX.type)
             val inner1EntryV = scopeAtEndOfThenBranch.getEntry("v") as ScopeEntry.GlobalVariable
             assertSame(vGlobal, inner1EntryV.astNode)
-            assertEquals(Type.I32, inner1EntryV.type)
+            assertEquals(Type.Reference(Type.I32, AddressSpace.FUNCTION, AccessMode.READ_WRITE), inner1EntryV.type)
             val inner1EntryY = scopeAtEndOfThenBranch.getEntry("y") as ScopeEntry.Parameter
             assertSame(yParam, inner1EntryY.astNode)
             assertEquals(Type.I32, inner1EntryY.type)
@@ -259,7 +259,7 @@ class ResolverTests {
             assertEquals(Type.F32, inner3EntryX.type)
             val inner3EntryV = scopeAtEndOfElseBranch.getEntry("v") as ScopeEntry.GlobalVariable
             assertSame(vGlobal, inner3EntryV.astNode)
-            assertEquals(Type.I32, inner3EntryV.type)
+            assertEquals(Type.Reference(Type.I32, AddressSpace.FUNCTION, AccessMode.READ_WRITE), inner3EntryV.type)
             val inner3EntryY = scopeAtEndOfElseBranch.getEntry("y") as ScopeEntry.Parameter
             assertSame(yParam, inner3EntryY.astNode)
             assertEquals(Type.I32, inner3EntryY.type)

--- a/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ResolverTests.kt
@@ -69,7 +69,10 @@ class ResolverTests {
         assertEquals(Type.Bool, environment.typeOf(whileCondition))
         val whileConditionInner = whileCondition.target as Expression.Binary
         assertEquals(Type.Bool, environment.typeOf(whileConditionInner))
-        assertEquals(Type.I32, environment.typeOf(whileConditionInner.lhs))
+        assertEquals(
+            Type.Reference(storeType = Type.I32, addressSpace = AddressSpace.FUNCTION, accessMode = AccessMode.READ_WRITE),
+            environment.typeOf(whileConditionInner.lhs),
+        )
         assertEquals(Type.AbstractInteger, environment.typeOf(whileConditionInner.rhs))
     }
 
@@ -230,7 +233,7 @@ class ResolverTests {
             assertEquals(Type.I32, inner1EntryY.type)
             val inner1EntryC = scopeAtEndOfThenBranch.getEntry("c") as ScopeEntry.LocalVariable
             assertSame(b1, inner1EntryC.astNode)
-            assertEquals(Type.F32, inner1EntryC.type)
+            assertEquals(Type.Reference(Type.F32, AddressSpace.FUNCTION, AccessMode.READ_WRITE), inner1EntryC.type)
         }
 
         run {
@@ -240,7 +243,7 @@ class ResolverTests {
             assertEquals(Type.F32, inner2EntryX.type)
             val inner2EntryV = scopeAtEndOfElseIfBranch.getEntry("v") as ScopeEntry.LocalVariable
             assertSame(c1, inner2EntryV.astNode)
-            assertEquals(Type.F32, inner2EntryV.type)
+            assertEquals(Type.Reference(Type.F32, AddressSpace.FUNCTION, AccessMode.READ_WRITE), inner2EntryV.type)
             val inner2EntryY = scopeAtEndOfElseIfBranch.getEntry("y") as ScopeEntry.Parameter
             assertSame(yParam, inner2EntryY.astNode)
             assertEquals(Type.I32, inner2EntryY.type)
@@ -262,7 +265,7 @@ class ResolverTests {
             assertEquals(Type.I32, inner3EntryY.type)
             val inner3EntryC = scopeAtEndOfElseBranch.getEntry("c") as ScopeEntry.LocalVariable
             assertSame(d1, inner3EntryC.astNode)
-            assertEquals(Type.Bool, inner3EntryC.type)
+            assertEquals(Type.Reference(Type.Bool, AddressSpace.FUNCTION, AccessMode.READ_WRITE), inner3EntryC.type)
         }
     }
 


### PR DESCRIPTION
Faithfully implement reference types following the WGSL language specification. This means that variables will be of reference type with the store type now containing the concrete variable type.

Closing: #86, #87.
