### PR TITLE
Add attribution to Graphics Fuzz sample shaders

### DIFF
--- a/samples/binarysearch_tree.wgsl
+++ b/samples/binarysearch_tree.wgsl
@@ -15,7 +15,7 @@
  */
 
 /*
- * Reimplemenation in WGSL of the GLSL shader from https://github.com/google/graphicsfuzz
+ * Reimplementation in WGSL of the GLSL shader from https://github.com/google/graphicsfuzz
  * Modifications were also made to utilise storing some data in uniforms
  * Original shader: https://github.com/google/graphicsfuzz/blob/master/shaders/src/main/glsl/samples/320es/stable_binarysearch_tree.frag
  */

--- a/samples/bubblesort_flag.wgsl
+++ b/samples/bubblesort_flag.wgsl
@@ -15,7 +15,7 @@
  */
 
 /*
- * Reimplemenation in WGSL of the GLSL shader from https://github.com/google/graphicsfuzz
+ * Reimplementation in WGSL of the GLSL shader from https://github.com/google/graphicsfuzz
  * Original shader: https://github.com/google/graphicsfuzz/blob/master/shaders/src/main/glsl/samples/320es/stable_bubblesort_flag.frag
  */
 


### PR DESCRIPTION
Added attribution comments of re implemented in wgsl graphics shaders:
- bubblesort_flag
- binarysearch_tree

This should be all the ones on main that need attributing. Let me know if there are any others.