### PR TITLE
Removed tests using texel_buffer in ParseTintTests

### DIFF
--- a/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
@@ -93,7 +93,11 @@ class ParseTintTests {
                 text.contains("enable subgroups") ||
                 // binding_array is not currently mentioned in the WGSL specification, but online
                 // research suggests that it is a naga extension.
-                text.contains("binding_array")
+                text.contains("binding_array") ||
+                // texel_buffers cannot be found within the WGSL specification. It is a proposal
+                // which is under active development and has not been standardised yet.
+                // Link to proposal: https://github.com/gpuweb/gpuweb/blob/main/proposals/texel-buffers.md
+                text.contains("texel_buffers")
             ) {
                 return@forEach
             }


### PR DESCRIPTION
Removed texel_buffer from test files used in ParseTintTests since it is currently in active development and not part of the wgsl specification. The proposal for it can be found here:
https://github.com/gpuweb/gpuweb/blob/main/proposals/texel-buffers.md

Fixes: #105