### PR TITLE
Added `declName` property on `ScopeEntry`

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -18,6 +18,19 @@ package com.wgslfuzz.core
 
 sealed interface ScopeEntry {
     val astNode: AstNode
+    val declName: String
+        get() =
+            when (this) {
+                is GlobalConstant -> this.astNode.name
+                is GlobalOverride -> this.astNode.name
+                is GlobalVariable -> this.astNode.name
+                is LocalValue -> this.astNode.name
+                is LocalVariable -> this.astNode.name
+                is Parameter -> this.astNode.name
+                is Struct -> this.astNode.name
+                is TypeAlias -> this.astNode.name
+                is Function -> this.astNode.name
+            }
 
     class Function(
         override val astNode: GlobalDecl.Function,


### PR DESCRIPTION
To do this I created an interface of `AstNode` that has a `name` property then made the `astNode` property on `ScopeEntry` have to be this interface. This meant the `declName` could have a provided implementation resulting in very little code changes in Resolver

Fixes: #107