### PR TITLE
Removed tests reliant on loops for triangle

### DIFF
--- a/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/TriangleTransformReduceTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/TriangleTransformReduceTests.kt
@@ -16,7 +16,6 @@
 
 package com.wgslfuzz.semanticspreservingtransformations
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotEquals
 
@@ -30,15 +29,13 @@ class TriangleTransformReduceTests : TransformReduceTests() {
         assertNotEquals(filenameNoExtension, "")
     }
 
-    @Disabled("TODO(https://github.com/mc-imperial/wgsl-fuzz/issues/170)")
     @Test
     override fun testAddDeadBreaks() {
-        super.testAddDeadBreaks()
+        // Ignoring test since no loops present hence cannot inject any breaks and so test will fail since transformed code won't change
     }
 
-    @Disabled("TODO(https://github.com/mc-imperial/wgsl-fuzz/issues/171)")
     @Test
     override fun testAddDeadContinues() {
-        super.testAddDeadContinues()
+        // Ignoring test since no loops present hence cannot inject any continues and so test will fail since transformed code won't change
     }
 }


### PR DESCRIPTION
Ignored continue and break tests since they are reliant on the sample having loops. Since Triangle sample shader does not have loops these transformations cannot be tested

Fixes: #170
Fixes: #171