### PR TITLE
Commenting `getNumericValueWithAdjustedExpression`

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/Common.kt
+++ b/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/Common.kt
@@ -751,7 +751,7 @@ private fun getNumericValueFromConstant(constantExpression: Expression): Int {
  * Takes in a constant expression and determines its value and outputs an adjusted expression if changes were made to make it conform to requirements.
  * Requirements:
  * - Correct output type
- * - If the value is a float with a fractional the function truncates the value and expression
+ * - If the value is a float with a fractional part the function truncates the value and expression
  * - If the value is outside the range which known values are allowed uses absolute and modulo to bring value within allowed range
  */
 private fun getNumericValueWithAdjustedExpression(
@@ -763,10 +763,10 @@ private fun getNumericValueWithAdjustedExpression(
     val value = getValueAsDoubleFromConstant(constantExpression)
 
     // Determine if truncation is necessary by checking if value has a fractional part
-    val truncate = value.toInt().toDouble() != value
+    val truncate = truncate(value) != value
 
     // Performs type cast and wraps in truncation if necessary
-    // Type casts to integer involve truncation and hence do not need to a call wgsl trunc function on top
+    // Type casts to integer involve truncation and hence do not need to a call wgsl trunc function in addition to their type cast
     val outputExpressionWithCastIfNeeded =
         if (outputType is Type.U32) {
             // This truncates - https://www.w3.org/TR/WGSL/#u32-builtin
@@ -787,7 +787,7 @@ private fun getNumericValueWithAdjustedExpression(
     val truncatedValue = truncate(value)
 
     // Brings the truncatedValue into the range 0..LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE if truncatedValue isn't in the range
-    // The operation to bring it into range is abs(truncatedValue) % LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE
+    // The operation to bring truncatedValue into range is abs(truncatedValue) % LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE
     val (outputValueInRangeAndInteger, outputExpressionWithCastAndInRange) =
         if (truncatedValue !in
             0.0..LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE.toDouble()

--- a/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/Common.kt
+++ b/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/Common.kt
@@ -468,6 +468,7 @@ fun generateKnownValueExpression(
                 )
             },
             fuzzerSettings.knownValueWeights.sumOfKnownValues(depth) to {
+                // Deriving a known value by using addition of two numbers.
                 val randomValue = fuzzerSettings.randomInt(knownValueAsInt + 1)
                 assert(randomValue <= knownValueAsInt)
                 val difference: Int = knownValueAsInt - randomValue
@@ -510,6 +511,7 @@ fun generateKnownValueExpression(
                 )
             },
             fuzzerSettings.knownValueWeights.differenceOfKnownValues(depth) to {
+                // Deriving a known value by using subtraction of two numbers.
                 val randomValue = fuzzerSettings.randomInt(LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE - knownValueAsInt + 1)
                 val sum: Int = knownValueAsInt + randomValue
                 assert(sum in 0..LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE)
@@ -550,6 +552,7 @@ fun generateKnownValueExpression(
                 )
             },
             fuzzerSettings.knownValueWeights.productOfKnownValues(depth) to {
+                // Deriving a known value by using multiplication of two numbers.
                 val randomValue = max(1, fuzzerSettings.randomInt(max(1, knownValueAsInt / 2)))
                 val quotient: Int = knownValueAsInt / randomValue
                 val remainder: Int = knownValueAsInt % randomValue
@@ -616,11 +619,12 @@ fun generateKnownValueExpression(
                     expression = resultExpression,
                 )
             },
+            // Deriving a known value from a uniform only works with concrete types.
             if (type.isAbstract()) {
                 // Removed by listOfNotNull
                 null
             } else {
-                // Deriving a known value from a uniform only works with concrete types.
+                // Deriving a known value from a uniform while adjusting as necessary using addition and subtraction.
                 fuzzerSettings.knownValueWeights.knownValueDerivedFromUniform(depth) to {
                     val (uniformScalar, valueOfUniform, scalarType) = randomUniformScalarWithValue(shaderJob, fuzzerSettings)
 


### PR DESCRIPTION
Changes:
- Commenting everything
- One slight code change to use a when clause instead of a if clause. If the value is outside the acceptable range the when clause will catch this whereas the if clause will not.

Fixes: #181 