### PR TITLE
Add utilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,3 +112,13 @@ tasks.register<JavaExec>("standAloneShaderHtml") {
     mainClass.set("com.wgslfuzz.tools.StandAloneShaderHtmlKt")
     classpath = sourceSets["main"].runtimeClasspath
 }
+
+tasks.register<JavaExec>("parseAndPrettyPrint") {
+    mainClass.set("com.wgslfuzz.tools.ParseAndPrettyPrintKt")
+    classpath = sourceSets["main"].runtimeClasspath
+}
+
+tasks.register<JavaExec>("printShaderWithCommentary") {
+    mainClass.set("com.wgslfuzz.tools.PrintShaderWithCommentaryKt")
+    classpath = sourceSets["main"].runtimeClasspath
+}

--- a/scripts/parseAndPrettyPrint
+++ b/scripts/parseAndPrettyPrint
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2025 The wgsl-fuzz Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./gradlew parseAndPrettyPrint --args="$*"

--- a/scripts/printShaderWithCommentary
+++ b/scripts/printShaderWithCommentary
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2025 The wgsl-fuzz Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+./gradlew printShaderWithCommentary --args="$*"

--- a/src/main/kotlin/com/wgslfuzz/tools/ParseAndPrettyPrint.kt
+++ b/src/main/kotlin/com/wgslfuzz/tools/ParseAndPrettyPrint.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The wgsl-fuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wgslfuzz.tools
+
+import com.wgslfuzz.core.AstWriter
+import com.wgslfuzz.core.LoggingParseErrorListener
+import com.wgslfuzz.core.parseFromFile
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ArgType
+import kotlinx.cli.required
+import java.io.FileOutputStream
+import java.io.PrintStream
+
+fun main(args: Array<String>) {
+    val parser = ArgParser("wgsl-fuzz pretty printer")
+
+    val shader by parser
+        .option(
+            ArgType.String,
+            fullName = "shader",
+            description = "Path to the shader to be pretty-printed",
+        ).required()
+
+    val output by parser
+        .option(
+            ArgType.String,
+            fullName = "output",
+            description = "File to which the pretty-printed shader will be written",
+        ).required()
+
+    parser.parse(args)
+
+    AstWriter(
+        PrintStream(FileOutputStream(output)),
+    ).emit(parseFromFile(shader, LoggingParseErrorListener()))
+}

--- a/src/main/kotlin/com/wgslfuzz/tools/PrintShaderWithCommentary.kt
+++ b/src/main/kotlin/com/wgslfuzz/tools/PrintShaderWithCommentary.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The wgsl-fuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wgslfuzz.tools
+
+import com.wgslfuzz.core.AstWriter
+import com.wgslfuzz.core.ShaderJob
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ArgType
+import kotlinx.cli.required
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileOutputStream
+import java.io.PrintStream
+
+fun main(args: Array<String>) {
+    val parser = ArgParser("wgsl-fuzz tool for printing a transformed shader with commentary")
+
+    val shaderJobFilename by parser
+        .option(
+            ArgType.String,
+            fullName = "shaderJob",
+            description = "Path to the shader job containing the shader to be printed",
+        ).required()
+
+    val output by parser
+        .option(
+            ArgType.String,
+            fullName = "output",
+            description = "File to which the shader will be written",
+        ).required()
+
+    parser.parse(args)
+
+    val shaderJob = Json.decodeFromString<ShaderJob>(File(shaderJobFilename).readText())
+
+    AstWriter(
+        out = PrintStream(FileOutputStream(output)),
+        emitCommentary = true,
+    ).emit(shaderJob.tu)
+}


### PR DESCRIPTION
Adds two small utilities:

- A utility that pretty-prints a shader; this is useful for getting a reference shader into a form that is easily comparable with a variant.

- A utility that pretty-prints a shader with associated commentary about transformations; this is useful when debugging.