### PR TITLE
Process shaders in sorted order

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/tools/RunJobsViaServer.kt
+++ b/src/main/kotlin/com/wgslfuzz/tools/RunJobsViaServer.kt
@@ -137,9 +137,11 @@ fun main(args: Array<String>) {
                 System.err.println("Job directory $jobDir does not exist.")
                 return
             }
-            dir.listFiles { file ->
-                file.isFile && file.extension == "wgsl"
-            } ?: emptyArray()
+            (
+                dir.listFiles { file ->
+                    file.isFile && file.extension == "wgsl"
+                } ?: emptyArray()
+            ).sortedArray()
         } else {
             System.err.println("One of jobFile or jobDir must be provided.")
             return


### PR DESCRIPTION
To assist in making experiments reproducible, shaders are now sent to the server in filename-sorted order.