### PR TITLE
Add node limit to generator, plus misc fixes

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/Resolver.kt
@@ -2258,6 +2258,7 @@ private fun resolveFunctionHeader(
         parameter.attributes.forEach {
             resolveAstNode(it, resolverState)
         }
+        resolveAstNode(parameter.typeDecl, resolverState)
     }
 
     functionDecl.returnAttributes.forEach {

--- a/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/TransformReduceTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/TransformReduceTests.kt
@@ -16,7 +16,9 @@
 
 package com.wgslfuzz.semanticspreservingtransformations
 
+import com.wgslfuzz.core.Expression
 import com.wgslfuzz.core.createShaderJob
+import com.wgslfuzz.core.nodesPreOrder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -100,6 +102,12 @@ abstract class TransformReduceTests {
         val shaderJobAsJson = Json.encodeToJsonElement(shaderJob)
         val transformedShaderJob = transformation(shaderJob, DefaultFuzzerSettings(generator))
         assertNotEquals(shaderJobAsJson, Json.encodeToJsonElement(transformedShaderJob))
+        // Ensure that every expression resolves to a type.
+        for (node in nodesPreOrder(transformedShaderJob.tu)) {
+            if (node is Expression) {
+                transformedShaderJob.environment.typeOf(node)
+            }
+        }
         val (reducedShaderJob, reductionMadeChanges) = transformedShaderJob.reduce { true }
         assertTrue(reductionMadeChanges)
         assertEquals(shaderJobAsJson, Json.encodeToJsonElement(reducedShaderJob))


### PR DESCRIPTION
Adds a configurable AST node limit to the generator. Moves logic that checks every node in the AST is typed so that this only runs in the TransformReduceTests, fixes a bug in that logic, and fixes a problem subsequently exposed by those tests wereby type declarations in parameters were not being resolved.