### PR TITLE
Retain known-value status of uniform

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/KnownValueExpressions.kt
+++ b/src/main/kotlin/com/wgslfuzz/semanticspreservingtransformations/KnownValueExpressions.kt
@@ -253,7 +253,7 @@ fun generateKnownValueExpression(
                     // uniformScalarAdjusted is uniformScalar wrapped in type casts, truncate and/or abs(x) % LARGEST_INTEGER_IN_PRECISE_FLOAT_RANGE.
                     val (valueOfUniformAdjusted: Int, uniformScalarAdjusted: Expression) =
                         getNumericValueWithAdjustedExpression(
-                            valueExpression = knownScalarFromUniform.expression,
+                            valueExpression = knownScalarFromUniform,
                             valueExpressionType = scalarType,
                             constantExpression = knownScalarFromUniform.knownValue,
                             outputType = type,


### PR DESCRIPTION
When adjusting a known value expression, ensure that the associated uniform expression is still a known value.

Related issue: #201.