### PR TITLE
Fix the way floats are turned into text

### DIFF
--- a/src/main/kotlin/com/wgslfuzz/core/ShaderJob.kt
+++ b/src/main/kotlin/com/wgslfuzz/core/ShaderJob.kt
@@ -18,6 +18,7 @@ package com.wgslfuzz.core
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -262,7 +263,17 @@ private fun literalExprFromBytes(
         is Type.F32 -> {
             return Pair(
                 Expression.FloatLiteral(
-                    text = Float.fromBits(wordFromBytes(bufferBytes, bufferByteIndex)).toString() + "f",
+                    text =
+                        BigDecimal
+                            .valueOf(
+                                Float
+                                    .fromBits(
+                                        wordFromBytes(
+                                            bufferBytes,
+                                            bufferByteIndex,
+                                        ),
+                                    ).toDouble(),
+                            ).toPlainString() + "f",
                 ),
                 bufferByteIndex + 4,
             )

--- a/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/LogicOperationsTransformReduceTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/semanticspreservingtransformations/LogicOperationsTransformReduceTests.kt
@@ -16,7 +16,6 @@
 
 package com.wgslfuzz.semanticspreservingtransformations
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotEquals
 
@@ -38,29 +37,5 @@ class LogicOperationsTransformReduceTests : TransformReduceTests() {
     @Test
     override fun testAddDeadContinues() {
         // This test does not have any loops hence cannot test dead continues
-    }
-
-    @Disabled
-    @Test
-    override fun testAddDeadReturns() {
-        super.testAddDeadReturns()
-    }
-
-    @Disabled
-    @Test
-    override fun testControlFlowWrapping() {
-        super.testControlFlowWrapping()
-    }
-
-    @Disabled
-    @Test
-    override fun testAddIdentityOperations() {
-        super.testAddIdentityOperations()
-    }
-
-    @Disabled
-    @Test
-    override fun testMultipleTransformations() {
-        super.testMultipleTransformations()
     }
 }


### PR DESCRIPTION
Depending on Float.toString() to turn a floating-point value into text suffered from a problem where toString() would round values to make output more readable, rather than giving a fully accurate representation of a floating-point value. This change uses BigDecimal to achieve an accurate representation.