### PR TITLE
renderShaderHtml waits for canvas to fully render

### DIFF
--- a/.github/workflows/semanticsPreserving.sh
+++ b/.github/workflows/semanticsPreserving.sh
@@ -23,7 +23,7 @@ help | head
 uname
 
 # TODO(https://github.com/mc-imperial/wgsl-fuzz/issues/220)
-ignoreList=("counting_sort" "logic_operations" "mergesort" "colorgrid_modulo" "pillars" "quicksort")
+ignoreList=("mergesort" "reverse_linked_list")
 
 numVariants=1
 # TODO(https://github.com/mc-imperial/wgsl-fuzz/issues/217) Determine better Mean Squared Error threshold

--- a/scripts/renderShaderHtml/cli.js
+++ b/scripts/renderShaderHtml/cli.js
@@ -73,7 +73,7 @@ async function capturePage(pagePath, outputDir) {
 
   const canvas = await page.waitForSelector("#thecanvas", { timeout: 1000 });
 
-  await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for half a second to render
+  await page.waitForSelector("#doneRender", { timeout: 10000 });
 
   await canvas.screenshot({
     path: outputDir + "/" + fileName + ".png",

--- a/src/main/kotlin/com/wgslfuzz/tools/StandAloneShaderHtml.kt
+++ b/src/main/kotlin/com/wgslfuzz/tools/StandAloneShaderHtml.kt
@@ -132,6 +132,12 @@ private fun renderStandAloneTemplate(
         |  const result = await executeJob(job, 1);
         |
         |  console.log(result);
+        |  
+        |  console.log("Done rendering");
+        |  const doneRenderDiv = document.createElement('div');
+        |  doneRenderDiv.textContent = 'Done rendering';
+        |  doneRenderDiv.id = 'doneRender';
+        |  document.getElementById('thecanvas').after(doneRenderDiv);
         |}
         |
         |main();


### PR DESCRIPTION
Added code to StandAloneShaderHtml so that once the canvas has rendered a html div is created with id doneRender which is then wait for in cli.js before taking a screenshot

Related issue: #220