### PR TITLE
Ignore failing parse tint tests

### DIFF
--- a/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
@@ -58,6 +58,7 @@ class ParseTintTests {
                 "external/dawn/test/tint/bug/tint/2201.wgsl.expected.wgsl",
                 "external/dawn/test/tint/bug/tint/1474-b.wgsl.expected.wgsl",
                 "external/dawn/test/tint/bug/chromium/1395241.wgsl.expected.wgsl",
+                "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionBody_PtrSampledImage.spvasm.expected.wgsl",
             ).map { it.replace("/", File.separator) }
 
         val tooHard =

--- a/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
+++ b/src/test/kotlin/com/wgslfuzz/core/ParseTintTests.kt
@@ -59,6 +59,10 @@ class ParseTintTests {
                 "external/dawn/test/tint/bug/tint/1474-b.wgsl.expected.wgsl",
                 "external/dawn/test/tint/bug/chromium/1395241.wgsl.expected.wgsl",
                 "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionBody_PtrSampledImage.spvasm.expected.wgsl",
+                "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionBody_ScalarNoChange.spvasm.expected.wgsl",
+                "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionCall_PtrImage_NoChange.spvasm.expected.wgsl",
+                "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionCall_PtrSampledImage_Split.spvasm.expected.wgsl",
+                "external/dawn/test/tint/reader/combined_texture_sampler/SplitCombinedImageSamplerPassTest_FunctionCall_PtrSampler_NoChange.spvasm.expected.wgsl",
             ).map { it.replace("/", File.separator) }
 
         val tooHard =


### PR DESCRIPTION
Ignore all tests containing SKIP: FAILED at the start of them